### PR TITLE
Dangling commas 

### DIFF
--- a/content/blog/kmeans-employment/index.Rmd
+++ b/content/blog/kmeans-employment/index.Rmd
@@ -119,7 +119,7 @@ kclusts <-
   tibble(k = 1:9) %>%
   mutate(
     kclust = map(k, ~kmeans(select(employment_demo, -occupation), .x)),
-    glanced = map(kclust, glance),
+    glanced = map(kclust, glance)
   )
 
 kclusts %>%

--- a/content/blog/kmeans-employment/index.html
+++ b/content/blog/kmeans-employment/index.html
@@ -110,7 +110,7 @@ tidy(employment_clust)</code></pre>
   tibble(k = 1:9) %&gt;%
   mutate(
     kclust = map(k, ~ kmeans(select(employment_demo, -occupation), .x)),
-    glanced = map(kclust, glance),
+    glanced = map(kclust, glance)
   )
 
 kclusts %&gt;%

--- a/content/blog/xgboost-tune-volleyball/index.Rmarkdown
+++ b/content/blog/xgboost-tune-volleyball/index.Rmarkdown
@@ -135,7 +135,7 @@ xgb_spec <- boost_tree(
   tree_depth = tune(), min_n = tune(), 
   loss_reduction = tune(),                     ## first three: model complexity
   sample_size = tune(), mtry = tune(),         ## randomness
-  learn_rate = tune(),                         ## step size
+  learn_rate = tune()                          ## step size
 ) %>% 
   set_engine("xgboost") %>% 
   set_mode("classification")

--- a/content/blog/xgboost-tune-volleyball/index.markdown
+++ b/content/blog/xgboost-tune-volleyball/index.markdown
@@ -161,13 +161,13 @@ An XGBoost model is based on trees, so we don't need to do much preprocessing fo
 
 ```r
 xgb_spec <- boost_tree(
-  trees = 1000, 
-  tree_depth = tune(), min_n = tune(), 
+  trees = 1000,
+  tree_depth = tune(), min_n = tune(),
   loss_reduction = tune(),                     ## first three: model complexity
   sample_size = tune(), mtry = tune(),         ## randomness
-  learn_rate = tune(),                         ## step size
-) %>% 
-  set_engine("xgboost") %>% 
+  learn_rate = tune()                          ## step size
+) %>%
+  set_engine("xgboost") %>%
   set_mode("classification")
 
 xgb_spec
@@ -175,7 +175,7 @@ xgb_spec
 
 ```
 ## Boosted Tree Model Specification (classification)
-## 
+##
 ## Main Arguments:
 ##   mtry = tune()
 ##   trees = 1000
@@ -184,7 +184,7 @@ xgb_spec
 ##   learn_rate = tune()
 ##   loss_reduction = tune()
 ##   sample_size = tune()
-## 
+##
 ## Computational engine: xgboost
 ```
 


### PR DESCRIPTION
Hello Julia,
I am working on a project to help students learn ML and MLOps.  I want to prioritize the functions to teach based on how many of your blog posts use a function.  So, I wrote code to parse all your blogs and count how often you use functions.  For example, when I did this a few months ago you used 422 functions... `library()` in all 52 posts, `recipe()` in  34 posts, etc.  My code which parses your repo chokes on two posts that have a dangling comma at the end of a function call.   I fixed them in a local copy but I want to keep updating the list as you add in more MLOps posts.  So, can you please fix the two things so I don't have to redo the corrections whenever I pull?